### PR TITLE
Deploying Metrifier to GCP with Cloud Deployment Manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,31 @@ You can find the following charts in [this jsfiddle](http://jsfiddle.net/juanped
 #### Conclusion
 
 Using JMH, we have checked out quickly the performance characteristics for both service architectures, and we can say that the RPC approach is noticeably faster.
+
+## Running in Google Cloud Platform
+
+See [this guide](deploy/README.md) to get information about how to deploy the different services in [Google Compute Engine](https://cloud.google.com/compute/).
+
+### Running the HTTP Server
+
+1. SSH into `http-server-vm` instance.
+2. Clone the project:
+```bash
+git clone https://github.com/47deg/metrifier.git && cd metrifier
+```
+3. Run the HTTP Server:
+```bash
+sbt "http/runMain metrifier.http.server.HttpServer"
+```
+
+### Chek out the HTTP Server
+
+1. SSH into `http-jmh-vm` instance.
+2. Clone the project:
+```bash
+git clone https://github.com/47deg/metrifier.git && cd metrifier
+```
+3. Run the following `GET` to fetch all the persons (replace `[INTERNAL_IP]` with the internal IP address asigned to the `http-jmh-vm` instance):
+```bash
+curl "http://[INTERNAL_IP]:8080/person"
+```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,62 @@
+# metrifier Deployment
+
+In this section we are putting together all the scripts and descriptors in order to deploy both `HTTP` and `RPC` servers to [Google Cloud Platform](https://cloud.google.com/).
+
+## Overview
+
+This is a [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/)
+configuration file that deploys all the virtual machine instances needed to run `metrifier`.
+
+## Deploy to GCP
+
+Set your default project ID. Replace `[MY_PROJECT]` with your own project ID:
+
+```bash
+gcloud config set project [MY_PROJECT]
+```
+
+First of all, we have to make files writable, so assuming you are in the root of `metrifier` project you can run:
+
+```bash
+chmod 644 deploy/metrifier.yaml
+chmod 644 deploy/*.jinja
+```
+
+Deploy the configuration:
+
+```bash
+gcloud deployment-manager deployments create metrifier-deployment --config deploy/metrifier.yaml
+```
+
+## Check your deployment's manifest
+
+A manifest is a read-only file that describes the deployment's resources in detail. Deployment Manager creates the manifest and logs any errors or warnings that occurred during deployment, which makes the manifest useful for troubleshooting.
+
+To look at your new deployment's manifest:
+
+```bash
+gcloud deployment-manager deployments describe metrifier-deployment
+```
+
+## Clean up
+
+Once you are done, you might want to clean up the deployment:
+
+
+```bash
+gcloud deployment-manager deployments delete metrifier-deployment
+```
+
+Type `y` at the prompt:
+
+```bash
+The following deployments will be deleted:
+- metrifier-deployment
+
+Do you want to continue (y/N)?  y
+
+Waiting for delete [operation-xxxx-xxxx-xxxxx-xxxxx]...done.
+Delete operation operation-xxxxx-xxx-xxxx-xxxx completed successfully.
+```
+
+The deployment will be permanently deleted.

--- a/deploy/metrifier.yaml
+++ b/deploy/metrifier.yaml
@@ -1,0 +1,8 @@
+imports:
+- path: tmpl-vm.jinja
+- path: tmpl-firewall.jinja
+- path: tmpl-compute.jinja
+
+resources:
+- name: compute-engine-setup
+  type: tmpl-compute.jinja

--- a/deploy/tmpl-compute.jinja
+++ b/deploy/tmpl-compute.jinja
@@ -1,0 +1,25 @@
+{% set FIREWALL = env["deployment"] + "-firewall" %}
+
+resources:
+- name: http-server-vm
+  type: tmpl-vm.jinja
+  properties:
+    machineType: n1-standard-1
+    zone: us-central1-f
+- name: rpc-server-vm
+  type: tmpl-vm.jinja
+  properties:
+    machineType: n1-standard-1
+    zone: us-central1-f
+- name: http-jmh-vm
+  type: tmpl-vm.jinja
+  properties:
+    machineType: g1-small
+    zone: us-central1-f
+- name: rpc-jmh-vm
+  type: tmpl-vm.jinja
+  properties:
+    machineType: g1-small
+    zone: us-central1-f
+- name: {{ FIREWALL }}
+  type: tmpl-firewall.jinja

--- a/deploy/tmpl-firewall.jinja
+++ b/deploy/tmpl-firewall.jinja
@@ -1,0 +1,10 @@
+{% set APPLICATION_PORT = 8080 %}
+
+resources:
+- name: {{ env["name"] }}
+  type: compute.v1.firewall
+  properties:
+    sourceRanges: ["0.0.0.0/0"]
+    allowed:
+    - IPProtocol: TCP
+      ports: [ {{ APPLICATION_PORT }} ]

--- a/deploy/tmpl-vm.jinja
+++ b/deploy/tmpl-vm.jinja
@@ -1,0 +1,37 @@
+{% set COMPUTE_URL_BASE = 'https://www.googleapis.com/compute/v1/' %}
+
+resources:
+- name: {{ env["name"] }}
+  type: compute.v1.instance
+  properties:
+    zone: {{ properties["zone"] }}
+    machineType: {{ COMPUTE_URL_BASE }}projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/{{ properties["machineType"] }}
+    disks:
+    - deviceName: boot
+      type: PERSISTENT
+      boot: true
+      autoDelete: true
+      initializeParams:
+        sourceImage: {{ COMPUTE_URL_BASE }}projects/debian-cloud/global/images/family/debian-8
+    networkInterfaces:
+    - network: {{ COMPUTE_URL_BASE }}projects/{{ env["project"] }}/global/networks/default
+      accessConfigs:
+      - name: external-nat
+        type: ONE_TO_ONE_NAT
+    metadata:
+      items:
+      - key: startup-script
+        value: |
+          #!/bin/bash
+          sudo apt-get update
+          sudo apt-get -y upgrade
+          sudo apt-get install -y git
+          sudo apt-get install -y software-properties-common python-software-properties
+          sudo apt-get update
+          sudo apt install -y -t jessie-backports  openjdk-8-jre-headless ca-certificates-java
+          sudo apt-get install -y openjdk-8-jre
+          sudo apt-get -y install apt-transport-https
+          echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+          sudo apt-get update
+          sudo apt-get install -y sbt=1.0.2


### PR DESCRIPTION
This PR brings the ability to deploy metrifier to GCP through Google Cloud Deployment Manager, following the provided guide.