### PR TITLE
Upgrade frees-rpc for Protobuf fix, fix http4s client, bump release

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,10 @@ sbt "demo/runMain metrifier.demo.RPCAvroDemoApp"
 We are using the [Java Microbenchmark Harness (JMH)](http://openjdk.java.net/projects/code-tools/jmh/) tool, which is helping us to get an experimental answer to a basic question about which implementation executes fastest among:
 
 * HTTP stack based on:
-  * `http4s`, version `0.18.12`.
+  * `http4s`, version `0.18.15`.
   * `circe`, version `0.9.3`.
 * RPC services stack based on:
-  * `freestyle`, version `0.8.0`.
-  * `frees-rpc`, version `0.14.0` (atop of [gRPC](https://grpc.io/), version `1.11.0`).
+  * `frees-rpc`, version `0.14.1` (atop of [gRPC](https://grpc.io/), version `1.11.0`).
 
 ### HTTP Benchmarks
 
@@ -216,7 +215,7 @@ shared/target/scala-2.12/metrifier-shared-assembly-[project-version].jar
 In this case, we've created a bucket named as `metrifier` within our GCP project. Assuming this name, these would be the set of commands to run (we're skipping the `bench` artifacts since we are not going to use them):
 
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 gsutil cp demo/target/scala-2.12/metrifier-demo-assembly-${METRIFIER_VERSION}-deps.jar gs://metrifier/jars
 gsutil cp frees-rpc/target/scala-2.12/metrifier-frees-rpc-assembly-${METRIFIER_VERSION}-deps.jar gs://metrifier/jars
 gsutil cp http/target/scala-2.12/metrifier-http-assembly-${METRIFIER_VERSION}-deps.jar gs://metrifier/jars
@@ -230,7 +229,7 @@ gsutil cp shared/target/scala-2.12/metrifier-shared-assembly-${METRIFIER_VERSION
 If the project dependencies have not changed, you could just upload the project JARs:
 
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 gsutil cp demo/target/scala-2.12/metrifier-demo-assembly-${METRIFIER_VERSION}.jar gs://metrifier/jars
 gsutil cp frees-rpc/target/scala-2.12/metrifier-frees-rpc-assembly-${METRIFIER_VERSION}.jar gs://metrifier/jars
 gsutil cp http/target/scala-2.12/metrifier-http-assembly-${METRIFIER_VERSION}.jar gs://metrifier/jars
@@ -250,7 +249,7 @@ Once everything is up, follow the next sections to run the benchmarks atop GCP.
 1. SSH into `http-server-vm` instance.
 2. Run the HTTP Server:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 env \
     HTTP_HOST=http-server-vm \
     HTTP_PORT=8080 \
@@ -268,7 +267,7 @@ curl "http://http-server-vm:8080/person"
 ```
 3. If step was successful, run the benchmarks:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 cd /metrifier/repo
 env \
     HTTP_HOST=http-server-vm \
@@ -285,7 +284,7 @@ Given the port `8080` was opened to the exterior when deploying the cluster with
 1. SSH into `rpc-proto-server-vm` instance.
 2. Run the RPC Protobuf based Server:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 env \
     RPC_HOST=rpc-proto-server-vm \
     RPC_PORT=8080 \
@@ -299,7 +298,7 @@ env \
 1. SSH into `rpc-proto-jmh-vm` instance.
 2. Run the benchmarks:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 cd /metrifier/repo
 env \
     RPC_HOST=rpc-proto-server-vm \
@@ -316,7 +315,7 @@ As we mentioned for the Http benchmarks, in this case we could also run the benc
 1. SSH into `rpc-avro-server-vm` instance.
 2. Run the RPC Avro based Server:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 env \
     RPC_HOST=rpc-avro-server-vm \
     RPC_PORT=8080 \
@@ -330,7 +329,7 @@ env \
 1. SSH into `rpc-avro-jmh-vm` instance.
 2. Run the benchmarks:
 ```bash
-export METRIFIER_VERSION=0.0.4
+export METRIFIER_VERSION=0.1.0
 cd /metrifier/repo
 env \
     RPC_HOST=rpc-avro-server-vm \

--- a/bench/src/main/scala/HttpBenchmark.scala
+++ b/bench/src/main/scala/HttpBenchmark.scala
@@ -16,7 +16,7 @@ import org.openjdk.jmh.annotations._
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpBenchmark {
 
-  def client = new HttpClient(Http1Client[IO]().unsafeRunSync(), HttpConf.host, HttpConf.port)
+  val client = new HttpClient(Http1Client[IO]().unsafeRunSync(), HttpConf.host, HttpConf.port)
 
   @Benchmark
   def listPersons: PersonList = client.listPersons.unsafeRunSync()

--- a/bench/src/main/scala/HttpBenchmark.scala
+++ b/bench/src/main/scala/HttpBenchmark.scala
@@ -63,4 +63,7 @@ class HttpBenchmark {
       pictureMedium = person.picture map (_.medium),
       pictureThumbnail = person.picture map (_.thumbnail)
     )
+
+  @TearDown
+  def stopClient(): Unit = client.shutdown()
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ lazy val http = project
   .settings(moduleName := "http")
   .settings(name := n(moduleName.value))
   .settings(commonSettings: _*)
-  .settings(scalaMetaSettings: _*)
   .settings(libraryDependencies ++= httpDependencies)
 
 lazy val `frees-rpc` = project

--- a/http/src/main/scala/client/HttpClient.scala
+++ b/http/src/main/scala/client/HttpClient.scala
@@ -2,7 +2,7 @@ package metrifier
 package http
 package client
 
-import cats.effect.Sync
+import cats.effect._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import metrifier.http.codecs._
@@ -12,7 +12,7 @@ import org.http4s.client.Client
 import org.http4s._
 
 
-class HttpClient[F[_]:Sync](c: Client[F], host: String, port: Int) {
+class HttpClient[F[_]: Effect](c: Client[F], host: String, port: Int) {
 
   private[this] val baseUrl = s"http://$host:$port"
   private[this] val baseUri: Uri = Uri
@@ -55,5 +55,7 @@ class HttpClient[F[_]:Sync](c: Client[F], host: String, port: Int) {
     c.expect(req)
 
   }
+
+  def shutdown(): Unit = c.shutdownNow()
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -12,8 +12,8 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      lazy val freesRPC = "0.14.0"
-      lazy val http4s   = "0.18.12"
+      lazy val freesRPC = "0.14.1"
+      lazy val http4s   = "0.18.15"
       lazy val config   = "1.3.3"
       lazy val logback  = "1.2.3"
       lazy val circe    = "0.9.3"
@@ -21,13 +21,12 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies += "ch.qos.logback" % "logback-classic" % V.logback,
-      scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Ypartial-unification")
+      scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds", "-Ypartial-unification")
     )
 
     lazy val scalaMetaSettings: Seq[Def.Setting[_]] = Seq(
       addCompilerPlugin("org.scalameta" % "paradise" % "3.0.0-M11" cross CrossVersion.full),
-      libraryDependencies += "org.scalameta" %% "scalameta" % "1.8.0",
-      scalacOptions ++= Seq("-Xplugin-require:macroparadise", "-language:higherKinds"),
+      scalacOptions ++= Seq("-Xplugin-require:macroparadise"),
       scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
     )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.6
+sbt.version = 1.2.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"      % "0.3.4")
-addSbtPlugin("com.eed3si9n"       % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly" % "0.14.7")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.4-SNAPSHOT"
+version in ThisBuild := "0.1.0"


### PR DESCRIPTION
This PR should allow the parent branch to be merged to master.

* Upgrade freestyle-rpc to 0.14.1 to get the fix for blocker https://github.com/frees-io/freestyle-rpc/issues/285.
* Fix an issue with the `http4s` client declaration that was causing HTTP benchmarks to fail after the 2nd or 3rd iteration.
* Upgrade versions in readme and remove reference to freestyle (no longer a dependency of frees-rpc).
* Remove scalameta dependency (keeping macroparadise compiler plugin).
* Bump a few dependencies including sbt.
* Bump version to 0.1.0 release.